### PR TITLE
Use std::borrow::Cow for input params

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,3 +13,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo build --release
+
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "context"
 description = "Authn/z context that is passed between TheHackerApp services"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 homepage = "https://github.com/TheHackerApp/context"
 repository = "https://github.com/TheHackerApp/context.git"

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,12 +7,13 @@ use axum::{
 use headers::HeaderMapExt;
 use http::{request::Parts, HeaderMap};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 /// Query parameters for fetching the event context
-#[derive(Debug, Deserialize)]
-pub struct Params {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Params<'p> {
     /// The domain to find the event context for
-    pub domain: String,
+    pub domain: Cow<'p, str>,
 }
 
 /// The event context response

--- a/src/user.rs
+++ b/src/user.rs
@@ -10,12 +10,13 @@ use axum::{
 use headers::HeaderMapExt;
 use http::{request::Parts, HeaderMap};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 /// Query parameters for fetching the user context
-#[derive(Debug, Deserialize)]
-pub struct Params {
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Params<'p> {
     /// The session token
-    pub token: String,
+    pub token: Cow<'p, str>,
 }
 
 /// The user context response


### PR DESCRIPTION
Switches to `std::borrow::Cow` for input params instead of an owned `String` to prevent unnecessary allocations. Also derives `serde::Serialize` for input params.