### PR TITLE
Allow querying event context by domain or slug

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,27 +3,32 @@ name: Publish
 
 on:  # yamllint disable-line rule:truthy
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
-  shipyard:
-    name: Shipyard
-    runs-on: ubuntu-22.04
+  release-plz:
+    name: Release Plz
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private_Key: ${{ secrets.RELEASE_PLZ_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: TheHackerApp/setup-rust@main
         with:
           ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
           token: ${{ secrets.SHIPYARD_TOKEN }}
 
-      - run: cargo publish
-
-  release:
-    name: Release
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
+      - uses: MarcoInei/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,13 @@
+[workspace]
+allow_dirty = false
+changelog_update = false
+git_release_enable = true
+git_release_draft = false
+git_tag_enable = true
+pr_draft = false
+pr_labels = ["release"]
+publish = true
+semver_check = false
+
+[[package]]
+name = "context"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ http = "0.2"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,6 +1,7 @@
 use headers::{Error, Header, HeaderName, HeaderValue};
 use std::{borrow::Borrow, iter, ops::Deref};
 
+static EVENT_DOMAIN: HeaderName = HeaderName::from_static("event-domain");
 static EVENT_SLUG: HeaderName = HeaderName::from_static("event-slug");
 static EVENT_ORGANIZATION_ID: HeaderName = HeaderName::from_static("event-organization-id");
 static USER_SESSION: HeaderName = HeaderName::from_static("user-session");
@@ -177,6 +178,11 @@ macro_rules! int_header {
             }
         }
     };
+}
+
+text_header! {
+    /// `Event-Domain` header containing a domain where the event can be found
+    ascii EventDomain, EVENT_DOMAIN
 }
 
 text_header! {


### PR DESCRIPTION
Updates the `event::Params` to allow querying by either the event's domain or slug. This would allow API requests where the event's slug is known ahead of time to be slightly faster.

Also adds automatic release generation using [`release-plz`](https://github.com/MarcoIeni/release-plz)