### PR TITLE
Make `event::Params` public

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -16,7 +16,7 @@ use std::{borrow::Cow, fmt::Formatter};
 /// Query parameters for fetching the event context
 #[derive(Debug)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
-enum Params<'p> {
+pub enum Params<'p> {
     /// Find event context for a domain
     Domain(Cow<'p, str>),
     /// Find event context for a slug


### PR DESCRIPTION
The `event::Params` enum was mistakenly made private in #5. This fixes it to ensure it can be used by consumers.