### PR TITLE
Separate deserializer and parameter lifetimes for event::Params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ http = "0.2"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+axum = { version = "0.6", default-features = false, features = ["headers", "query"] }
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
Fixes an "implementation is not general enough error" when trying to use `event::Params` with the [axum Query](https://docs.rs/axum/0.6.20/axum/extract/struct.Query.html) extractor by decoupling the `deserializer` lifetime from the resulting `event::Params` lifetime.

Example error:
```
error: implementation of `Deserialize` is not general enough
  --> src/handlers.rs:37:20
   |
37 |     Query(params): Query<Params<'static>>,
   |                    ^^^^^ implementation of `Deserialize` is not general enough
   |
   = note: `Deserialize<'0>` would have to be implemented for the type `context::event::Params<'static>`, for any lifetime `'0`...
   = note: ...but `Deserialize<'1>` is actually implemented for the type `context::event::Params<'1>`, for some specific lifetime `'1`
```