### PR TITLE
Feature gate header conversion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,27 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   default:
-    name: Library
+    name: Library (no features)
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
       - run: cargo build --release
+
+  feature:
+    name: Library (${{ matrix.feature }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - extract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo build --release -F ${{ matrix.feature }}
 
   test:
     name: Test
@@ -21,4 +35,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: cargo test
+      - run: cargo test --all-features
+
+  test-feature:
+    name: Test (${{ matrix.feature }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - extract
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo test -F ${{ matrix.feature }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,16 @@ publish = ["wafflehacks"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "0.6", default-features = false, features = ["headers"] }
-headers = "0.3"
-http = "0.2"
+axum = { version = "0.6", default-features = false, features = ["headers"], optional = true }
+headers = { version = "0.3", optional = true }
+http = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 axum = { version = "0.6", default-features = false, features = ["headers", "query"] }
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+
+[features]
+default = []
+extract = ["axum", "headers", "http"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 /// Context information from the `events` service
 pub mod event;
+#[cfg(feature = "extract")]
 mod headers;
 /// Context information from the `identity` service
 pub mod user;
 
+#[cfg(feature = "extract")]
 pub use headers::*;
 
 #[cfg(test)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,13 +1,17 @@
+#[cfg(feature = "extract")]
 use crate::headers::{
     OAuthProviderSlug, OAuthUserEmail, OAuthUserId, UserEmail, UserFamilyName, UserGivenName,
     UserId, UserIsAdmin, UserSession,
 };
+#[cfg(feature = "extract")]
 use axum::{
     async_trait,
     extract::{rejection::TypedHeaderRejection, FromRequestParts, TypedHeader},
     RequestPartsExt,
 };
+#[cfg(feature = "extract")]
 use headers::HeaderMapExt;
+#[cfg(feature = "extract")]
 use http::{request::Parts, HeaderMap};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -37,6 +41,7 @@ pub enum Context {
 
 impl Context {
     /// Serialize the context into request headers
+    #[cfg(feature = "extract")]
     pub fn into_headers(self) -> HeaderMap {
         let mut map = HeaderMap::with_capacity(1);
         self.write_headers(&mut map);
@@ -44,6 +49,7 @@ impl Context {
     }
 
     /// Write the context to request headers
+    #[cfg(feature = "extract")]
     pub fn write_headers(self, headers: &mut HeaderMap) {
         match self {
             Context::Unauthenticated => headers.typed_insert(UserSession::Unauthenticated),
@@ -60,6 +66,7 @@ impl Context {
     }
 }
 
+#[cfg(feature = "extract")]
 #[async_trait]
 impl<S> FromRequestParts<S> for Context
 where
@@ -97,6 +104,7 @@ pub struct RegistrationNeededContext {
 
 impl RegistrationNeededContext {
     /// Write the context to request headers
+    #[cfg(feature = "extract")]
     fn write_headers(self, headers: &mut HeaderMap) {
         headers.typed_insert(OAuthProviderSlug::from(self.provider));
         headers.typed_insert(OAuthUserId::from(self.id));
@@ -104,6 +112,7 @@ impl RegistrationNeededContext {
     }
 }
 
+#[cfg(feature = "extract")]
 #[async_trait]
 impl<S> FromRequestParts<S> for RegistrationNeededContext
 where
@@ -142,6 +151,7 @@ pub struct AuthenticatedContext {
 
 impl AuthenticatedContext {
     /// Write the context to request headers
+    #[cfg(feature = "extract")]
     fn write_headers(self, headers: &mut HeaderMap) {
         headers.typed_insert(UserId::from(self.id));
         headers.typed_insert(UserGivenName::from(self.given_name));
@@ -151,6 +161,7 @@ impl AuthenticatedContext {
     }
 }
 
+#[cfg(feature = "extract")]
 #[async_trait]
 impl<S> FromRequestParts<S> for AuthenticatedContext
 where
@@ -175,7 +186,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "extract"))]
 mod tests {
     use super::{AuthenticatedContext, Context, RegistrationNeededContext};
     use crate::{error_test_cases, request};


### PR DESCRIPTION
Moves the header generation and retrieval components behind the `extract` feature to allow non-web services/crates to utilize the contexts without polluting the dependency tree.