### PR TITLE
Add checks for validating context attributes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         feature:
           - extract
+          - graphql
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -45,6 +46,7 @@ jobs:
       matrix:
         feature:
           - extract
+          - graphql
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ publish = ["wafflehacks"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-graphql = { version = "6.0", default-features = false, optional = true }
 axum = { version = "0.6", default-features = false, features = ["headers"], optional = true }
 headers = { version = "0.3", optional = true }
 http = { version = "0.2", optional = true }
@@ -24,3 +25,4 @@ tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 [features]
 default = []
 extract = ["axum", "headers", "http"]
+graphql = ["async-graphql"]

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -1,0 +1,41 @@
+use crate::user::{self, AuthenticatedContext};
+use async_graphql::{Context, Error, ErrorExtensions, Result};
+
+/// Create an [`async_graphql::Guard`] out of a check function
+pub fn guard<F, R>(check: F) -> impl Fn(&Context<'_>) -> Result<()> + Send + Sync + 'static
+where
+    F: Fn(&Context<'_>) -> Result<R> + Send + Sync + 'static,
+{
+    move |ctx| check(ctx).map(|_| ())
+}
+
+/// An error raised when the user has invalid permissions
+#[derive(Debug)]
+pub struct Forbidden;
+
+impl From<Forbidden> for Error {
+    fn from(_: Forbidden) -> Self {
+        Error::new("forbidden").extend_with(|_, extensions| extensions.set("code", "FORBIDDEN"))
+    }
+}
+
+/// Check if the requester is authenticated
+pub fn is_authenticated<'c>(ctx: &'c Context) -> Result<&'c AuthenticatedContext> {
+    let user = ctx.data_unchecked::<user::Context>();
+
+    match user {
+        user::Context::Authenticated(context) => Ok(context),
+        _ => Err(Forbidden.into()),
+    }
+}
+
+/// Check if the requester is an administrator
+pub fn is_admin(ctx: &Context<'_>) -> Result<()> {
+    let user = is_authenticated(ctx)?;
+
+    if user.is_admin {
+        Ok(())
+    } else {
+        Err(Forbidden.into())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+/// Pre-condition checks for use with [`async-graphql`](https://docs.rs/async-graphql)
+#[cfg(feature = "graphql")]
+pub mod checks;
 /// Context information from the `events` service
 pub mod event;
 #[cfg(feature = "extract")]
@@ -5,6 +8,8 @@ mod headers;
 /// Context information from the `identity` service
 pub mod user;
 
+#[cfg(feature = "graphql")]
+pub use checks::guard;
 #[cfg(feature = "extract")]
 pub use headers::*;
 


### PR DESCRIPTION
Adds checks to validate attributes about the different contexts. These can be used as [`async_graphql::Guard`](https://docs.rs/async-graphql/6.0.10/async_graphql/trait.Guard.html) via the `guard` function.