### PR TITLE
Update axum to 0.7 and simplify direct dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,17 +12,16 @@ publish = ["wafflehacks"]
 
 [dependencies]
 async-graphql = { version = "6.0", default-features = false, optional = true }
-axum = { version = "0.6", default-features = false, features = ["headers"], optional = true }
-headers = { version = "0.3", optional = true }
-http = { version = "0.2", optional = true }
+axum = { version = "0.7", default-features = false, optional = true }
+axum-extra = { version = "0.9", features = ["typed-header"], optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-axum = { version = "0.6", default-features = false, features = ["headers", "query"] }
+axum = { version = "0.7", default-features = false, features = ["query"] }
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
 default = []
-extract = ["axum", "headers", "http"]
+extract = ["axum", "axum-extra"]
 graphql = ["async-graphql"]

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,4 +1,4 @@
-use headers::{Error, Header, HeaderName, HeaderValue};
+use axum_extra::headers::{Error, Header, HeaderName, HeaderValue};
 use std::{borrow::Borrow, iter, ops::Deref};
 
 static EVENT_DOMAIN: HeaderName = HeaderName::from_static("event-domain");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod test_util {
             $( $name:expr => $value:expr ),* $(,)?
         ) => {
             {
-                let request = ::http::request::Request::builder()
+                let request = ::axum::http::request::Request::builder()
                     $( .header($name, $value) )*
                     .body(())
                     .unwrap();

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -3,13 +3,15 @@ use crate::headers::{EventOrganizationId, EventSlug, RequestScope};
 #[cfg(feature = "extract")]
 use axum::{
     async_trait,
-    extract::{rejection::TypedHeaderRejection, FromRequestParts},
-    RequestPartsExt, TypedHeader,
+    extract::FromRequestParts,
+    http::{request::Parts, HeaderMap},
+    RequestPartsExt,
 };
 #[cfg(feature = "extract")]
-use headers::HeaderMapExt;
-#[cfg(feature = "extract")]
-use http::{request::Parts, HeaderMap};
+use axum_extra::{
+    headers::HeaderMapExt,
+    typed_header::{TypedHeader, TypedHeaderRejection},
+};
 use serde::{
     de::{Error as _, MapAccess, Visitor},
     ser::SerializeMap,
@@ -205,13 +207,16 @@ mod tests {
 mod extract_tests {
     use super::{Context, EventContext, Params};
     use crate::{error_test_cases, request};
-    use axum::extract::{rejection::TypedHeaderRejectionReason, FromRequestParts, Query};
-    use http::Request;
+    use axum::{
+        extract::{FromRequestParts, Query},
+        http::Request,
+    };
+    use axum_extra::typed_header::TypedHeaderRejectionReason;
     use std::borrow::Cow;
 
     #[tokio::test]
     async fn params_domain_from_request() {
-        let request = http::request::Request::builder()
+        let request = Request::builder()
             .uri("/context?domain=wafflehacks.org")
             .body(())
             .unwrap();
@@ -225,7 +230,7 @@ mod extract_tests {
 
     #[tokio::test]
     async fn params_slug_from_request() {
-        let request = http::request::Request::builder()
+        let request = Request::builder()
             .uri("/context?slug=wafflehacks-2023")
             .body(())
             .unwrap();

--- a/src/user.rs
+++ b/src/user.rs
@@ -6,13 +6,15 @@ use crate::headers::{
 #[cfg(feature = "extract")]
 use axum::{
     async_trait,
-    extract::{rejection::TypedHeaderRejection, FromRequestParts, TypedHeader},
+    extract::FromRequestParts,
+    http::{request::Parts, HeaderMap},
     RequestPartsExt,
 };
 #[cfg(feature = "extract")]
-use headers::HeaderMapExt;
-#[cfg(feature = "extract")]
-use http::{request::Parts, HeaderMap};
+use axum_extra::{
+    headers::HeaderMapExt,
+    typed_header::{TypedHeader, TypedHeaderRejection},
+};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -190,8 +192,8 @@ where
 mod tests {
     use super::{AuthenticatedContext, Context, RegistrationNeededContext};
     use crate::{error_test_cases, request};
-    use axum::extract::{rejection::TypedHeaderRejectionReason, FromRequestParts};
-    use http::Request;
+    use axum::{extract::FromRequestParts, http::Request};
+    use axum_extra::typed_header::TypedHeaderRejectionReason;
 
     #[tokio::test]
     async fn from_request_valid_unauthenticated() {


### PR DESCRIPTION
Updates `axum` to 0.7.x and removes unnecessary direct dependencies, preferring to use re-exports to ensure version compatibility. The `axum-extra` crate was added as the `TypedHeader` was relocated.