### PR TITLE
Revert to stable axum and async-graphql versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,17 +11,18 @@ publish = ["wafflehacks"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-graphql = { git = "https://github.com/TheHackerApp/async-graphql.git", branch = "axum-7", default-features = false, optional = true }
-axum = { version = "0.7", default-features = false, optional = true }
-axum-extra = { version = "0.9", features = ["typed-header"], optional = true }
+async-graphql = { version = "6.0", default-features = false, optional = true }
+axum = { version = "0.6", default-features = false, features = ["headers"], optional = true }
+headers = { version = "0.3", optional = true }
+http = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-axum = { version = "0.7", default-features = false, features = ["query"] }
+axum = { version = "0.6", default-features = false, features = ["headers", "query"] }
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
 default = []
-extract = ["axum", "axum-extra"]
+extract = ["axum", "headers", "http"]
 graphql = ["async-graphql"]

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,4 +1,4 @@
-use axum_extra::headers::{Error, Header, HeaderName, HeaderValue};
+use headers::{Error, Header, HeaderName, HeaderValue};
 use std::{borrow::Borrow, iter, ops::Deref};
 
 static EVENT_DOMAIN: HeaderName = HeaderName::from_static("event-domain");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod test_util {
             $( $name:expr => $value:expr ),* $(,)?
         ) => {
             {
-                let request = ::axum::http::request::Request::builder()
+                let request = ::http::request::Request::builder()
                     $( .header($name, $value) )*
                     .body(())
                     .unwrap();

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -3,15 +3,13 @@ use crate::headers::{EventOrganizationId, EventSlug, RequestScope};
 #[cfg(feature = "extract")]
 use axum::{
     async_trait,
-    extract::FromRequestParts,
-    http::{request::Parts, HeaderMap},
-    RequestPartsExt,
+    extract::{rejection::TypedHeaderRejection, FromRequestParts},
+    RequestPartsExt, TypedHeader,
 };
 #[cfg(feature = "extract")]
-use axum_extra::{
-    headers::HeaderMapExt,
-    typed_header::{TypedHeader, TypedHeaderRejection},
-};
+use headers::HeaderMapExt;
+#[cfg(feature = "extract")]
+use http::{request::Parts, HeaderMap};
 use serde::{
     de::{Error as _, MapAccess, Visitor},
     ser::SerializeMap,
@@ -207,16 +205,13 @@ mod tests {
 mod extract_tests {
     use super::{Context, EventContext, Params};
     use crate::{error_test_cases, request};
-    use axum::{
-        extract::{FromRequestParts, Query},
-        http::Request,
-    };
-    use axum_extra::typed_header::TypedHeaderRejectionReason;
+    use axum::extract::{rejection::TypedHeaderRejectionReason, FromRequestParts, Query};
+    use http::Request;
     use std::borrow::Cow;
 
     #[tokio::test]
     async fn params_domain_from_request() {
-        let request = Request::builder()
+        let request = http::request::Request::builder()
             .uri("/context?domain=wafflehacks.org")
             .body(())
             .unwrap();
@@ -230,7 +225,7 @@ mod extract_tests {
 
     #[tokio::test]
     async fn params_slug_from_request() {
-        let request = Request::builder()
+        let request = http::request::Request::builder()
             .uri("/context?slug=wafflehacks-2023")
             .body(())
             .unwrap();

--- a/src/user.rs
+++ b/src/user.rs
@@ -6,15 +6,13 @@ use crate::headers::{
 #[cfg(feature = "extract")]
 use axum::{
     async_trait,
-    extract::FromRequestParts,
-    http::{request::Parts, HeaderMap},
+    extract::{rejection::TypedHeaderRejection, FromRequestParts, TypedHeader},
     RequestPartsExt,
 };
 #[cfg(feature = "extract")]
-use axum_extra::{
-    headers::HeaderMapExt,
-    typed_header::{TypedHeader, TypedHeaderRejection},
-};
+use headers::HeaderMapExt;
+#[cfg(feature = "extract")]
+use http::{request::Parts, HeaderMap};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -192,8 +190,8 @@ where
 mod tests {
     use super::{AuthenticatedContext, Context, RegistrationNeededContext};
     use crate::{error_test_cases, request};
-    use axum::{extract::FromRequestParts, http::Request};
-    use axum_extra::typed_header::TypedHeaderRejectionReason;
+    use axum::extract::{rejection::TypedHeaderRejectionReason, FromRequestParts};
+    use http::Request;
 
     #[tokio::test]
     async fn from_request_valid_unauthenticated() {


### PR DESCRIPTION
The release of axum 0.7 is too new to update to across projects. As a result, this reverts back to the previous stable version of both dependencies.

This reverts commits 53708e708fc72c5d7bb74d6dc83f69359269f05a and 5060b91a9564ebf64d2ec414fd93ea83d6d8e898.