### PR TITLE
Allow contexts to be used directly as a header response

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -4,6 +4,7 @@ use crate::headers::{EventOrganizationId, EventSlug, RequestScope};
 use axum::{
     async_trait,
     extract::{rejection::TypedHeaderRejection, FromRequestParts},
+    response::{IntoResponse, Response},
     RequestPartsExt, TypedHeader,
 };
 #[cfg(feature = "extract")]
@@ -134,6 +135,13 @@ where
                 Self::Event(EventContext::from_request_parts(parts, state).await?)
             }
         })
+    }
+}
+
+#[cfg(feature = "extract")]
+impl IntoResponse for Context {
+    fn into_response(self) -> Response {
+        self.into_headers().into_response()
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -7,6 +7,7 @@ use crate::headers::{
 use axum::{
     async_trait,
     extract::{rejection::TypedHeaderRejection, FromRequestParts, TypedHeader},
+    response::{IntoResponse, Response},
     RequestPartsExt,
 };
 #[cfg(feature = "extract")]
@@ -87,6 +88,13 @@ where
                 Self::Authenticated(AuthenticatedContext::from_request_parts(parts, state).await?)
             }
         })
+    }
+}
+
+#[cfg(feature = "extract")]
+impl IntoResponse for Context {
+    fn into_response(self) -> Response {
+        self.into_headers().into_response()
     }
 }
 


### PR DESCRIPTION
Allows the user and scope contexts to be serialized into response headers instead of being returned as JSON. This will allow easier processing by nginx as it is trivial to extract data from headers whereas parsing JSON is more involved.