### PR TITLE
Extract context from headers independent of axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,20 @@ publish = ["wafflehacks"]
 
 [dependencies]
 async-graphql = { version = "6.0", default-features = false, optional = true }
-axum = { version = "0.6", default-features = false, features = ["headers"], optional = true }
+async-trait = { version = "0.1", optional = true }
+axum-core = { version = "0.3", default-features = false, optional = true }
 headers = { version = "0.3", optional = true }
 http = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-axum = { version = "0.6", default-features = false, features = ["headers", "query"] }
+axum = { version = "0.6", default-features = false, features = ["query"] }
 serde_json = "1"
 serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 
 [features]
+axum = ["async-trait", "axum-core", "headers"]
 default = []
-extract = ["axum", "headers", "http"]
 graphql = ["async-graphql"]
+headers = ["dep:headers", "http"]


### PR DESCRIPTION
Makes the process of extracing the user and scope contexts independent of the [axum `FromRequestParts` trait](https://docs.rs/axum/0.6.20/axum/extract/trait.FromRequestParts.html). Instead, a `TryFrom` implementation is added to pull directly from a [`HeaderMap`](https://docs.rs/http/0.2.11/http/header/struct.HeaderMap.html). As a result, the `FromRequestParts` implementation is now simply a wrapper around the TryFrom implementation.

This also makes the extraction process fully synchronous, increasing the areas in which it can be used.