### PR TITLE
Use feature powerset for CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,11 @@ jobs:
     name: Generate Build Matrix
     runs-on: ubuntu-22.04
     outputs:
-      features: ${{ steps.generate-matrix.outputs.features }}
+      features: ${{ steps.generator.outputs.features }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dasel
-        run: |
-          mkdir -p $HOME/.local/bin
-          DOWNLOAD_URL=$(gh api /repos/tomwright/dasel/releases/latest -q '.assets[] | select(.name == "dasel_linux_amd64") | .browser_download_url')
-          curl -sSLf $DOWNLOAD_URL -o $HOME/.local/bin/dasel
-          chmod +x $HOME/.local/bin/dasel
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Generate matrix from Cargo features
-        id: generate-matrix
-        run: |
-          FEATURES=$(dasel -f Cargo.toml -w json --pretty=false '.features.keys()')
-          echo "features=$FEATURES" >> "$GITHUB_OUTPUT"
+      - uses: TheHackerApp/feature-powerset-action@main
+        id: generator
 
   library:
     name: Library (${{ matrix.feature }})


### PR DESCRIPTION
Switch to using a powerset of the crate's features for building to ensure everything works with everything else.

The matrix elements are generated using a the [TheHackerApp/feature-powerset-action](https://github.com/TheHackerApp/feature-powerset-action).