### PR TITLE
Implement `IntoResponseParts` for the contexts

### DIFF
--- a/src/scope.rs
+++ b/src/scope.rs
@@ -3,7 +3,7 @@ use crate::headers::{extract, EventOrganizationId, EventSlug, RequestScope};
 #[cfg(feature = "axum")]
 use axum_core::{
     extract::FromRequestParts,
-    response::{IntoResponse, Response},
+    response::{IntoResponse, IntoResponseParts, Response, ResponseParts},
 };
 #[cfg(feature = "headers")]
 use headers::HeaderMapExt;
@@ -145,6 +145,16 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         Self::try_from(&parts.headers)
+    }
+}
+
+#[cfg(feature = "axum")]
+impl IntoResponseParts for Context {
+    type Error = std::convert::Infallible;
+
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        self.write_headers(res.headers_mut());
+        Ok(res)
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -6,7 +6,7 @@ use crate::headers::{
 #[cfg(feature = "axum")]
 use axum_core::{
     extract::FromRequestParts,
-    response::{IntoResponse, Response},
+    response::{IntoResponse, IntoResponseParts, Response, ResponseParts},
 };
 #[cfg(feature = "headers")]
 use headers::HeaderMapExt;
@@ -98,6 +98,16 @@ where
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
         Self::try_from(&parts.headers)
+    }
+}
+
+#[cfg(feature = "axum")]
+impl IntoResponseParts for Context {
+    type Error = std::convert::Infallible;
+
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        self.write_headers(res.headers_mut());
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
Implements [`IntoResponseParts`](https://docs.rs/axum/0.6.20/axum/response/trait.IntoResponseParts.html) for `scope::Context` and `user::Context` to allow both to be returned by the same handler. While this was possible previously using the `write_headers` method, it is now more ergonomic.