### PR TITLE
Add default token for unauthenticated sessions

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -21,6 +21,7 @@ use std::borrow::Cow;
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Params<'p> {
     /// The session token
+    #[serde(default)]
     pub token: Cow<'p, str>,
 }
 


### PR DESCRIPTION
When deserializing the `token` field of `user::Params`, we will now use an empty string as the default value if it is missing. This ensures that requests that do not yet have a session can get a sensible error message instead of a non-sensical internal one.