### PR TITLE
Reorganize crate for usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Context
 
-The authentication and authorization context that is passed between services for The Hacker App services.
+The authentication and authorization context that is passed between The Hacker App services.

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,3 +1,4 @@
+//! Typed headers for passing context information
 use crate::user::UserRole;
 #[cfg(feature = "axum")]
 use axum_core::response::{IntoResponse, Response};


### PR DESCRIPTION
Re-organizes the crate to provide better usability and documentation. All header types are exposed under the `headers` module to reduce clutter. Similarly, the individual context types are exported from the root of the crate.

The context types were renamed from `scope::Context` and `user::Context` to `Scope` and `User`, respectively. This prevents collisions when both are imported into the same module.

Additional documentation was also added.